### PR TITLE
Do not check text if in Link or Image or BlockQuote

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "husky": "^0.13.3",
     "mocha": "^3.2.0",
     "textlint-scripts": "^1.2.2"
+  },
+  "dependencies": {
+    "textlint-rule-helper": "^2.0.0"
   }
 }

--- a/src/one-white-space-between-zenkaku-and-hankaku-eiji.js
+++ b/src/one-white-space-between-zenkaku-and-hankaku-eiji.js
@@ -7,15 +7,22 @@
 
 "use strict";
 
+import { RuleHelper } from "textlint-rule-helper";
+
 const ZEN_HAN = /(?:[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]|[\uD840-\uD87F][\uDC00-\uDFFF]|[ぁ-んァ-ヶ])[A-Za-z]/;
 const HAN_ZEN = /[A-Za-z](?:[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]|[\uD840-\uD87F][\uDC00-\uDFFF]|[ぁ-んァ-ヶ])/;
 const ALLOW_CHARS = ["、", "。", "「", "」", "（", "）", "｛", "｝", "【", "】", "『", "』"];
 
 export default context => {
+    const helper = new RuleHelper(context);
     const { Syntax, getSource, RuleError, report } = context;
 
     return {
         [Syntax.Str](node) {
+            if (helper.isChildNode(node, [Syntax.Link, Syntax.Image, Syntax.BlockQuote])) {
+                return;
+            }
+
             const text = getSource(node);
             let err = false;
             let matches, index, c;

--- a/test/one-white-space-between-zenkaku-and-hankaku-eiji.spec.js
+++ b/test/one-white-space-between-zenkaku-and-hankaku-eiji.spec.js
@@ -22,7 +22,10 @@ tester.run("one-white-space-between-zenkaku-and-hankaku-eiji", rule, {
         "、Hello World。",
         "（Hello World）",
         "『Hello World』",
-        "【Hello World】"
+        "【Hello World】",
+        "> ハローワールドHello World",
+        "[ハローワールドHello World](http://example.dev)",
+        "![ハローワールドHello World](http://example.dev/img.png)"
     ],
     invalid: [
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2750,6 +2750,12 @@ textlint-plugin-text@^1.0.1:
   dependencies:
     txt-to-ast "^1.0.2"
 
+textlint-rule-helper@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/textlint-rule-helper/-/textlint-rule-helper-2.0.0.tgz#95cb4696c95c4258d2e3389e9e64b849f9721382"
+  dependencies:
+    unist-util-visit "^1.1.0"
+
 textlint-scripts@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/textlint-scripts/-/textlint-scripts-1.2.2.tgz#cc4fba615d971d662a6b9989e0da1a0b8de9d1e2"


### PR DESCRIPTION
With this commit, this rule does not check text if it is child node of Link or Image or BlockQuote.